### PR TITLE
fix escaped space in mkdir application support

### DIFF
--- a/ether.rb
+++ b/ether.rb
@@ -8,7 +8,6 @@ class Ether < Formula
 
   def install
     bin.install "ether"
-    system "mkdir ~/Library/Application\ Support/Ether"
-    system "mkdir ~/Library/Application\ Support/Ether/Templates"
+    system "mkdir", "-p", "$HOME/Library/Application Support/Ether/Templates"
   end
 end


### PR DESCRIPTION
i think this will fix the problem.
<img width="884" alt="screen shot 2017-10-26 at 3 13 03 pm" src="https://user-images.githubusercontent.com/1342803/32072535-d8592b62-ba60-11e7-892f-9410cb45be61.png">
